### PR TITLE
Fix a bug that somwtimes colorize option doesn't work

### DIFF
--- a/lib/rack/spyup.rb
+++ b/lib/rack/spyup.rb
@@ -6,7 +6,7 @@ module Rack
   class SpyUp
     def initialize(app, &instance_configure)
       @app = app
-      @colorize = true
+      @colorize = self.class.config.colorize
       @logger   = self.class.config.logger
       instance_configure.call(self) if block_given?
     end

--- a/lib/rack/spyup/configuration.rb
+++ b/lib/rack/spyup/configuration.rb
@@ -2,11 +2,12 @@ require 'rack/spyup'
 module Rack
   class SpyUp
     class Configuration
-      attr_accessor :enabled_environments, :logger
+      attr_accessor :enabled_environments, :logger, :colorize
 
       def self.default
         new.tap do |config|
           config.enabled_environments = %w(development)
+          config.colorize = true
           config.logger = nil
         end
       end

--- a/spec/lib/rack-spyup_spec.rb
+++ b/spec/lib/rack-spyup_spec.rb
@@ -35,6 +35,7 @@ describe Rack::SpyUp do
       mock_app do
         use Rack::SpyUp do |mw|
           mw.logger = _logger
+          mw.colorize = true
         end
         run lambda {|env| [200, {"Content-Type" => "text/html"}, ["OK"]]}
       end
@@ -50,6 +51,24 @@ describe Rack::SpyUp do
         use Rack::SpyUp do |mw|
           mw.logger = _logger
           mw.colorize = false
+        end
+        run lambda {|env| [200, {"Content-Type" => "text/html"}, ["OK"]]}
+      end
+
+      get "/hello"
+      @output.rewind
+      expect(@output.read).not_to match(/\e\[\d+m/)
+    end
+
+    it "should not contain colored log when configured by 'Rack::SpyUp.config'" do
+      Rack::SpyUp.config do |config|
+        config.colorize = false
+      end
+
+      _logger = Logger.new(@output)
+      mock_app do
+        use Rack::SpyUp do |mw|
+          mw.logger = _logger
         end
         run lambda {|env| [200, {"Content-Type" => "text/html"}, ["OK"]]}
       end


### PR DESCRIPTION
If colorize option is declared like this:

``` ruby
Rack::SpyUp.config do |config|
  config.colorize = false
end
```

Then it'll just blow up and you'll get:

```
NoMethodError: undefined method `colorize=' for #<Rack::SpyUp::Configuration:0x00000000ff15e0>
```

This commit fixes this bug and now `colorize` options can be configured properly on Rails.
